### PR TITLE
bug fix to add in zindex prop

### DIFF
--- a/src/js/component-owner.js
+++ b/src/js/component-owner.js
@@ -118,7 +118,7 @@ class ComponentOwner extends React.Component {
 		}
 
 		return (
-			<div id={this.props.opts.id} className="o-coach-mark__container" style={{ zIndex: 990 }}>
+			<div id={this.props.opts.id} className="o-coach-mark__container"  style={{ zIndex: this.props.opts.zIndex || 990 }}>
 				<div className="o-coach-mark__content-container">
 					<div className={`o-coach-mark__content ${this.props.placement}`}>
 						{/*titlebar*/}


### PR DESCRIPTION
To add back zindex prop so that this prop can we used as an optional config value.Need this for console where the section code tool tip coachmark is hiding below the app header @nlkluth @Katjax10 