### PR TITLE
added informative / yellow coachmark option

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ title          | text    | no       | The title
 text           | text    | yes      | The body of the coach mark
 srCloseText    | text    | no       | The screen reader text that calls out the close button (default is "Close Dialog")
 id             | text    | yes      | unique identifier - can be anything as long as no other HTML element has this value as an id
+type           | text    | no       | The type of coach mark you want to display (default is "default", informative is "info")
 offsetX        | int     | no       | moves the mark left/right
 offsetY        | int     | no       | moves the mark up/down
 disableShadow  | boolean | no       | Prevents the darkening of the rest of the page when an element is highlighted. Default is false
@@ -40,6 +41,7 @@ zIndex         | int     | no       | keeps coachmark on top or below other HTML
 forceAbove     | boolean | no       | forces the coach mark to be above element
 forceBelow     | boolean | no       | forces the coach mark to be below element
 stopScroll     | boolean | no       | Stops coach mark from moving the view
+
 
 
 ```

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -5,7 +5,8 @@ export const showFirst = () => {
     elementId: 'demo-target1',
     opts: {
       title: 'Default Coach Mark',
-      text: 'Assuming the consumer only passes in .title and .text'
+      text: 'Assuming the consumer only passes in .title and .text',
+      type: 'default'
     }
   });
 };
@@ -18,7 +19,8 @@ export const showSecond = () => {
       text: 'Consumer passes in .forceAbove, .disableShadowing, and .gotIt',
       gotIt: true,
       forceAbove: true,
-      disableShadowing: true
+      disableShadowing: true,
+      type: 'default'
     }
   });
 };
@@ -31,13 +33,15 @@ export const showThird = () => {
       text: 'Consumer passes in .disablePointer and a callback that shows another coach-mark',
       gotIt: true,
       disablePointer: true,
+      type: 'default'
     },
     callback: () => {
       new CoachMark({
         elementId: 'demo-target3',
         opts: {
           text: 'You closed it the coach-mark.  Great job!',
-          forceBelow: true
+          forceBelow: true,
+          type: 'default'
         }
       })
     }
@@ -49,7 +53,19 @@ export const showFourth = () => {
     elementId: 'demo-target4',
     opts: {
       title: '<h4>Coach Wrapped in h4 HTML tags</h4>',
-      text: '<a href="#">Text that is a clickable link</a>'
+      text: '<a href="#">Text that is a clickable link</a>',
+      type: 'default'
+    }
+  });
+};
+
+export const showFifth = () => {
+  new CoachMark({
+    elementId: 'demo-target5',
+    opts: {
+      title: 'Information Coach Mark',
+      text: 'Assuming the consumer only passes in .title and .text',
+      type: 'info'
     }
   });
 };

--- a/demo/index.html
+++ b/demo/index.html
@@ -55,6 +55,12 @@
         <button type="button" onclick="showFourth()">Show</button>
     </div>
 
+    <h2>Fifth Example</h2>
+    <div id="demo-target5" class="demo-target">
+        This Coachmark is informational
+        <button type="button" onclick="showFifth()">Show</button>
+    </div>
+
     <!-- Provide React and ReactDOM as a dependency external to the component -->
     <script crossorigin src="https://unpkg.com/react@latest/umd/react.development.js"></script>
     <script crossorigin src="https://unpkg.com/react-dom@latest/umd/react-dom.development.js"></script>

--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ export default class CoachMark {
   }
 
   removeCoachMark = (event) => {
+    // IE 11 polyfill for .remove();
     if (!('remove' in Element.prototype)) {
       Element.prototype.remove = function() {
         if (this.parentNode) {

--- a/src/js/component-owner.js
+++ b/src/js/component-owner.js
@@ -12,6 +12,7 @@ class ComponentOwner extends Component {
   static propTypes = {
     target: PropTypes.object.isRequired,
     title: PropTypes.string,
+    type: PropTypes.string,
     text: PropTypes.string,
     id: PropTypes.string,
     onClose: PropTypes.func,
@@ -33,7 +34,8 @@ class ComponentOwner extends Component {
     offsetX: 0,
     offsetY: 0,
     srCloseText: 'Close dialog',
-    zIndex: 1200
+    zIndex: 1200,
+    type: 'default'
   };
 
   constructor(props) {
@@ -56,6 +58,7 @@ class ComponentOwner extends Component {
   }
 
   componentDidMount() {
+    console.log(this.props);
     const buttons = document.querySelectorAll('button');
     const coachmarkButtons = document.querySelectorAll('.o-coach-mark__container button');
 
@@ -153,7 +156,7 @@ class ComponentOwner extends Component {
     const placement = this.getPlacement();
     return (
       <div ref={(node) => {this.container = node}} id={this.props.id} className="o-coach-mark__container"  style={{ zIndex: this.props.zIndex }}>
-        <div ref={(node) => {this.contentContainer = node}} className="o-coach-mark__content-container">
+        <div ref={(node) => {this.contentContainer = node}} className={this.props.type === 'info' ? 'o-coach-mark__content-container info' : 'o-coach-mark__content-container default'}>
           <button
             type="button"
             className="o-coach-mark__close-icon"

--- a/src/js/component-owner.js
+++ b/src/js/component-owner.js
@@ -58,7 +58,6 @@ class ComponentOwner extends Component {
   }
 
   componentDidMount() {
-    console.log(this.props);
     const buttons = document.querySelectorAll('button');
     const coachmarkButtons = document.querySelectorAll('.o-coach-mark__container button');
 

--- a/src/scss/component-owner.scss
+++ b/src/scss/component-owner.scss
@@ -19,11 +19,27 @@
 	&__content-container {
 		padding: 20px 24px;
 		margin: 10px;
-		background-color: $pe-color-digital-ice-blue;
 		border-radius: 4px;
 		box-shadow: 0 3px 7px rgba(0,0,0,0.25);
 		min-width: 280px;
 		float: left;
+		&.default {
+			background-color: $pe-color-digital-ice-blue;
+			.o-coach-mark__content {
+				&::before {
+					background-color: $pe-color-digital-ice-blue;
+				}
+			}
+
+		}
+		&.info {
+			background-color: $pe-color-sunshine-yellow;
+			.o-coach-mark__content {
+				&::before {
+					background-color: $pe-color-sunshine-yellow;
+				}
+			}
+		}
 	}
 	&__title {
 		padding-bottom: 4px;
@@ -72,7 +88,6 @@
 		position: absolute;
 		width: 16px;
 		height: 16px;
-		background-color: $pe-color-digital-ice-blue;
 		transform: rotate( 45deg );
 	}
 


### PR DESCRIPTION
Added an information style coachmark.

There is now an option to pass in a 'type' prop which toggles the display of the coachmark.  The default type is 'default' which renders ice blue.  You can pass in 'info' to the type to display the sunflower yellow version.

Readme has also been updated.
